### PR TITLE
Test against multiple platforms & Ruby versions on GH-Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,20 +1,22 @@
 name: Ruby
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
+    strategy:
+      matrix:
+        ruby: [2.4, 2.5, 2.6, 2.7]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: eregon/use-ruby-action@master
       with:
-        ruby-version: 2.6.x
-    - name: Build and test with Rake
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
+        ruby-version: ${{ matrix.ruby }}
+    - run: gem install bundler
+    - run: bundle install --jobs 4 --retry 3
+    - run: bundle exec rake


### PR DESCRIPTION
eregon/use-ruby-action is used in workflow instead of actions/setup-ruby
because the latter doesn't yet support Ruby 2.7. See actions/setup-ruby#45