### PR TITLE
Add support for JRuby on Windows

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,10 +8,6 @@ jobs:
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7, jruby]
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          # eregon/use-ruby-action doesn't support JRuby on Windows
-          - ruby: jruby
-            platform: windows-latest
 
     runs-on: ${{ matrix.platform }}
 
@@ -21,9 +17,9 @@ jobs:
       uses: eregon/use-ruby-action@master
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Build and Test
-      shell: bash
+    - name: Build
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
-        bundle exec rake
+    - name: Test
+      run: bundle exec rake test

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 class TestUnitColor < Test::Unit::TestCase
-  test "Exit with status 1 when missing argument" do
-    system('bundle', 'exec', 'epubcheck')
+  test "Exit with status 1 when given nonexistent path" do
+    system('bundle', 'exec', 'epubcheck', '/nonexistent')
     assert_equal 1, $?.exitstatus
   end
 


### PR DESCRIPTION
1. I had to change test that checks `bundle exec epubcheck` because it hits Bundler bug: rubygems/bundler#7602
2. GitHub Actions script is adjusted to use native OS shell to avoid weird issues and to also avoid rubygems/bundler#7602